### PR TITLE
page.goto() hungs up forever

### DIFF
--- a/source/Page.js
+++ b/source/Page.js
@@ -54,7 +54,7 @@ class Page extends EventEmitter {
 
         await waitFor(
             options.timeout,
-            ()  =>  this._target.Busy  &&  (this._target.Busy == false)
+            ()  =>  (this._target.Busy == false)
         );
 
         this.document = proxyCOM( this._target.Document );


### PR DESCRIPTION
Code quote as following will make page.goto hung up forever, because ` this._target.Busy  &&  (this._target.Busy == false)` will always evaluate to false.
```javascript 
    async waitForNavigation(options = {timeout: 30000}) {

        await waitFor(
            options.timeout,
            ()  =>  this._target.Busy  &&  (this._target.Busy == false)
        );
```